### PR TITLE
Update swagger config to support getById, getAll, update, and delete for merchant redirect QRs

### DIFF
--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -108,6 +108,50 @@ paths:
       tags:
         - Merchant redirect QR
     parameters: []
+    get:
+      summary: Get all QRs
+      operationId: get-v1-merchantRedirect
+      responses:
+        '200':
+          description: OK
+      description: Get all QRs created for one saleunit
+  '/v1/merchantRedirect/{id}':
+    put:
+      summary: ''
+      operationId: put-v1-merchantRedirect
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MerchantRedirectQrResponse'
+      description: Update redirectUrl
+    delete:
+      summary: ''
+      operationId: delete-v1-merchantRedirect
+      responses:
+        '200':
+          description: OK
+      description: Delete QR
+    parameters:
+      - schema:
+          type: string
+        name: id
+        in: path
+        required: true
+        description: id for QR
+    get:
+      summary: ''
+      operationId: get-v1-merchantRedirect-id
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MerchantRedirectQrResponse'
+      description: Get QR from id
 components:
   schemas:
     LandingPageUrl:

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -88,6 +88,14 @@ paths:
       responses:
         '200':
           description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MerchantRedirectQrResponseGetAll'
+        '400':
+          description: Bad Request
+        '401':
+          description: Unauthorized
       description: Get all QRs created for one saleunit
   '/v1/merchantRedirect/{id}':
     put:
@@ -225,6 +233,12 @@ components:
       required:
         - id
         - url
+    MerchantRedirectQrResponseGetAll:
+      title: MerchantRedirectQrResponseGetAll
+      x-examples: {}
+      type: array
+      items:
+        $ref: '#/components/schemas/MerchantRedirectQrResponse'
   securitySchemes:
     BearerToken:
       type: http

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -84,7 +84,7 @@ paths:
     parameters: []
     get:
       summary: Get all QRs
-      operationId: get-v1-merchantRedirect
+      operationId: GetAllMerchantRedirectQrs
       responses:
         '200':
           description: OK
@@ -97,10 +97,15 @@ paths:
         '401':
           description: Unauthorized
       description: Get all QRs created for one saleunit
+      tags:
+        - Merchant redirect QR
+      parameters:
+        - $ref: '#/components/parameters/Authorization'
+        - $ref: '#/components/parameters/Ocp-Apim-Subscription-Key'
   '/v1/merchantRedirect/{id}':
     put:
-      summary: ''
-      operationId: put-v1-merchantRedirect
+      summary: Update QR redirectUrl
+      operationId: UpdateMerchantRedirectUrl
       responses:
         '200':
           description: OK
@@ -108,14 +113,38 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/MerchantRedirectQrResponse'
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
       description: Update redirectUrl
+      tags:
+        - Merchant redirect QR
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/MerchantRedirectQrUpdateRequest'
+      parameters:
+        - $ref: '#/components/parameters/Accept'
+        - $ref: '#/components/parameters/Authorization'
+        - $ref: '#/components/parameters/Ocp-Apim-Subscription-Key'
     delete:
-      summary: ''
-      operationId: delete-v1-merchantRedirect
+      summary: Delete QR
+      operationId: DeleteMerchantRedirectQr
       responses:
         '200':
           description: OK
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
       description: Delete QR
+      tags:
+        - Merchant redirect QR
+      parameters:
+        - $ref: '#/components/parameters/Authorization'
+        - $ref: '#/components/parameters/Ocp-Apim-Subscription-Key'
     parameters:
       - schema:
           type: string
@@ -124,8 +153,8 @@ paths:
         required: true
         description: id for QR
     get:
-      summary: ''
-      operationId: get-v1-merchantRedirect-id
+      summary: Get all saleunit QRs
+      operationId: GetMerchantRedirectQrById
       responses:
         '200':
           description: OK
@@ -133,7 +162,16 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/MerchantRedirectQrResponse'
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
       description: Get QR from id
+      tags:
+        - Merchant redirect QR
+      parameters:
+        - $ref: '#/components/parameters/Authorization'
+        - $ref: '#/components/parameters/Ocp-Apim-Subscription-Key'
 components:
   schemas:
     OneTimePaymentQrRequest:
@@ -239,6 +277,18 @@ components:
       type: array
       items:
         $ref: '#/components/schemas/MerchantRedirectQrResponse'
+    MerchantRedirectQrUpdateRequest:
+      title: MerchantRedirectQrUpdateRequest
+      type: object
+      description: Model for put-requests
+      properties:
+        redirectUrl:
+          type: string
+          format: uri
+          pattern: '^https:\/\/[\w\.]+([\w#!:.?+=&%@\-\/]+)?$'
+          example: 'https://example.com/myProduct'
+      required:
+        - redirectUrl
   securitySchemes:
     BearerToken:
       type: http

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -109,7 +109,7 @@ paths:
           description: Unauthorized
         '404':
           description: Not Found
-      description: Update redirectUrl
+      description: Update the redirect url (target destination) of the QR
       tags:
         - Merchant redirect QR
       requestBody:
@@ -145,7 +145,7 @@ paths:
         required: true
         description: id for QR
     get:
-      summary: Get all saleunit QRs
+      summary: Get Merchant Redirect QR by id
       operationId: GetMerchantRedirectQrById
       responses:
         '200':

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -84,8 +84,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/MerchantRedirectQrResponseGetAll'
-        '400':
-          description: Bad Request
         '401':
           description: Unauthorized
       description: Get all QRs created for one saleunit
@@ -105,10 +103,14 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/MerchantRedirectQrResponse'
+        '400':
+          $ref: '#/components/responses/400BadRequest'
         '401':
           description: Unauthorized
         '404':
-          description: Not Found
+          $ref: '#/components/responses/404NotFound'
+        '415':
+          $ref: '#/components/responses/415UnsupportedMediaType'
       description: Update the redirect url (target destination) of the QR
       tags:
         - Merchant redirect QR
@@ -130,7 +132,7 @@ paths:
         '401':
           description: Unauthorized
         '404':
-          description: Not Found
+          $ref: '#/components/responses/404NotFound'
       description: Delete QR
       tags:
         - Merchant redirect QR
@@ -157,7 +159,7 @@ paths:
         '401':
           description: Unauthorized
         '404':
-          description: Not Found
+          $ref: '#/components/responses/404NotFound'
       description: Get QR from id
       tags:
         - Merchant redirect QR
@@ -350,6 +352,12 @@ components:
             properties:
               id:
                 type: string
+    404NotFound:
+      description: Not found
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/QrErrorResponse'
 tags:
   - name: Merchant redirect QR
   - name: One time payment QR


### PR DESCRIPTION
This PR adds some new types, and configurations for endpoints regarding getById, getAll, update, and delete for merchant redirect QRs. 

This makes it possible to get all QRs from one saleunit, and the response will be like this:
```json
[
  {
    "id": "billboard_1",
    "url": "https://qr.vipps.no/generate/qr.png?..."
  },
  {
    "id": "billboard_2",
    "url": "https://qr.vipps.no/generate/qr.png?..."
  }
]
```
It also makes it possible to get by id, and update, but the response is the same as the post-endpoint.
Delete will return HTTP status code.

