### PR TITLE
Update

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ sidebar_position: 1
 ---
 END_METADATA -->
 
-# Vipps QR API version 2
+# Vipps QR API
 
 <!-- START_COMMENT -->
 
@@ -20,8 +20,8 @@ Review the [Getting Started](https://github.com/vippsas/vipps-developers/blob/ma
 
 ## QR API
 
-* [Vipps QR API Guide](vipps-qr-api.md): Developer guide for the Vipps QR API.
-* [Swagger](https://vippsas.github.io/vipps-qr-api/) or [ReDoc](https://vippsas.github.io/vipps-developer-docs/api/qr): QR API Reference Specifications.
+* [API Guide](vipps-qr-api.md): Developer guide for the Vipps QR API.
+* [API Reference](https://vippsas.github.io/vipps-developer-docs/api/qr): QR API Reference Specifications.
 
 ## Examples
 

--- a/vipps-qr-api-faq.md
+++ b/vipps-qr-api-faq.md
@@ -16,7 +16,7 @@ Document version 1.2.1.
 ## Table of Contents
 
 * [See the Vipps eCom API FAQ](#see-the-vipps-ecom-api-faq)
-* [Can we make our own QR code based on the Vipps deeplink URL?](#can-we-make-our-own-qr-code-based-on-the-vipps-deeplink-url)
+* [Can we make our own QRs for payment and redirects?](#can-we-make-our-own-qrs-for-payment-and-redirects)
 * [Why are there extra API calls to retrieve the QR code?](#why-are-there-extra-api-calls-to-retrieve-the-qr-code)
 * [Questions?](#questions)
 
@@ -48,10 +48,10 @@ Yes, there is one extra API call, but the overhead is minimal.
 With current HTTP technology, the user will not notice any delay.
 
 ## What happens with the user after the payment?
-Currently, the user will be redirected to a fallback url after the payment is completed. The recommendation is to set `fallBack` parameter in the ecom/recurring initiate body to `https://www.vipps.no/thankyoupage/`. 
 
-We are working on a flow where the user will end up on the receipt in the Vipps after the payment is complete. Work is expected to be done by May 2022.
+Currently, the user will be redirected to a fallback url after the payment is completed. The recommendation is to set `fallBack` parameter in the ecom/recurring initiate body to `https://www.vipps.no/thankyoupage/`.
 
+We are working on a flow where the user will end up on the receipt in the Vipps app after the payment is complete. Work is expected to be done by May 2022.
 
 ## Questions?
 

--- a/vipps-qr-api-postman.md
+++ b/vipps-qr-api-postman.md
@@ -53,7 +53,7 @@ Under the *Merchant Redirect QR* folder:
 
 1. Send request `Generate QR`.
 
-   This creates a QR that works as a redirect back to the merchant. The website is specified as the `redirectUrl` in the [`POST:/qr/v1/merchant-redirect`](https://vippsas.github.io/vipps-qr-api/redoc.html#tag/Merchant-redirect-QR/operation/CreateMerchantRedirectQr) request.
+   This creates a QR that works as a redirect back to the merchant. The website is specified as the `redirectUrl` in the [`POST:/qr/v1/merchant-redirect`](https://vippsas.github.io/vipps-developer-docs/api/qr#tag/Merchant-redirect-QR/operation/CreateMerchantRedirectQr) request.
 
    The `qr-id` variable is now set in the environment for use with subsequent calls.
 
@@ -64,25 +64,25 @@ Under the *Merchant Redirect QR* folder:
 2. Send request `Get QR by id`.
 
    This gets the QR for the specified `qr-id` in
-[`GET:/qr/v1/merchant-redirect/{{qr-id}}`](https://vippsas.github.io/vipps-qr-api/redoc.html#tag/Merchant-redirect-QR/operation/GetMerchantRedirectQrById).
+[`GET:/qr/v1/merchant-redirect/{{qr-id}}`](https://vippsas.github.io/vipps-developer-docs/api/qr#tag/Merchant-redirect-QR/operation/GetMerchantRedirectQrById).
 
    Ctrl+click the link to see the QR code. When you scan it, it will take you to the specified URL.
 
 3. Send request `Update redirectUrl by id`.
 
    This changes the URL for the QR code with the specified `qr-id` in
-[`PUT:/qr/v1/merchant-redirect/{{qr-id}}`](https://vippsas.github.io/vipps-qr-api/redoc.html#tag/Merchant-redirect-QR/operation/UpdateMerchantRedirectUrl).
+[`PUT:/qr/v1/merchant-redirect/{{qr-id}}`](https://vippsas.github.io/vipps-developer-docs/api/qr#tag/Merchant-redirect-QR/operation/UpdateMerchantRedirectUrl).
 
 4. Send request `Delete QR by id`.
 
    This deletes the QR code with the specified `qr-id` in
-[`DEL:/qr/v1/merchant-redirect/{{qr-id}}`](https://vippsas.github.io/vipps-qr-api/redoc.html#tag/Merchant-redirect-QR/operation/DeleteMerchantRedirectQr).
+[`DEL:/qr/v1/merchant-redirect/{{qr-id}}`](https://vippsas.github.io/vipps-developer-docs/api/qr#tag/Merchant-redirect-QR/operation/DeleteMerchantRedirectQr).
 
 5. Send request `Get all QRs`.
 
-   This gets all the QRs by calling [`GET:/qr/v1/merchant-redirect`](https://vippsas.github.io/vipps-qr-api/redoc.html#tag/Merchant-redirect-QR/operation/GetAllMerchantRedirectQrs) request.
+   This gets all the QRs by calling [`GET:/qr/v1/merchant-redirect`](https://vippsas.github.io/vipps-developer-docs/api/qr#tag/Merchant-redirect-QR/operation/GetAllMerchantRedirectQrs) request.
 
-See the [QR API Specifications](https://vippsas.github.io/vipps-qr-api/redoc.html) for details about the calls.
+See the [QR API Specifications](https://vippsas.github.io/vipps-developer-docs/api/qr) for details about the calls.
 
 #### 3. Run One-Time Payment QR Examples
 
@@ -90,13 +90,13 @@ Under the *One-Time Payment QR* folder:
 
 1. Send request `Initiate Payment`.
 
-   This uses [`POST:/v3/psppayments/init/`](https://vippsas.github.io/vipps-ecom-api/#/Vipps%20eCom%20API/initiatePaymentV3UsingPOST)
+   This uses [`POST:/v3/psppayments/init/`](https://vippsas.github.io/vipps-developer-docs/api/ecom#tag/Vipps-eCom-API/operation/initiatePaymentV3UsingPOST)
    from the [Vipps eComm API](https://github.com/vippsas/vipps-ecom-api).
 
    The `orderId` and `vippsLandingPageUrl` variables are now in the environment of this Postman example
 
 1. Send request `Generate OTP QR`. This supplies `vippsLandingPageUrl` to
- [`POST:/qr/v1`](https://vippsas.github.io/vipps-qr-api/#/One%20time%20payment%20QR/generateOtpQr) to provide a url that can be used to show a QR code.
+ [`POST:/qr/v1`](https://vippsas.github.io/vipps-developer-docs/api/qr/#tag/One-time-payment-QR/operation/generateOtpQr) to provide a url that can be used to show a QR code.
 
    Ctrl+click the link to see the QR code. Scanning the QR should open the test app on your phone and allow you to complete the one-time purchase.
 

--- a/vipps-qr-api-postman.md
+++ b/vipps-qr-api-postman.md
@@ -41,12 +41,14 @@ Import the collection by following the steps below:
    - `Ocp-Apim-Subscription-Key`
 
 ### Step 4: Run tests
+
 #### 1. Get access token
 
 Send request `Get Access Token`. This provides you with access to the API.
 
 The access token is valid for 1 hour in the test environment
 and 24 hours in the production environment.
+
 #### 2. Run Merchant Redirect QR Examples
 
 Under the *Merchant Redirect QR* folder:

--- a/vipps-qr-api.md
+++ b/vipps-qr-api.md
@@ -25,7 +25,6 @@ Document version 1.2.2.
 
 - [Before you begin](#before-you-begin)
   * [Vipps HTTP headers](#vipps-http-headers)
-    - [Example headers](#example-headers)
   * [Authentication](#authentication)
   * [QR formats](#qr-formats)
 - [One-Time Payment QR Codes](#one-time-payment-qr-codes)
@@ -104,7 +103,6 @@ The QR code image will be returned as a URL in the response for both one-time pa
 The URL to the image does not require any authentication and can be shown wherever you want. Note that one-time payment QRs eventually will time out - trying to open the URL to the otp-QR image after its expiry while will return a 404. Merchant redirect QRs can be opened forever.
 
 Below is an example merchant redirect QR:
-
 
 !["Demo "](images/demo-qr.png)
 
@@ -213,6 +211,7 @@ The response will be similar to this, where the URL in the responseBody will be 
 **Please note:** The `expiresIn` value is in seconds.
 
 See the [step-by-step postman guide](vipps-qr-api-postman.md) for an example.
+
 ## Merchant Redirect QR codes
 
 Merchant redirect QR codes allows you to make printable QR
@@ -269,6 +268,7 @@ The `id` parameter is required, and is defined by the merchant. You can later us
 See the [step-by-step postman guide](vipps-qr-api-postman.md) for an example.
 
 #### Updating and Deletion of QRs
+
 Updating QRs is a very similar procedure to creating them. When a QR is updated, nothing happens to the QR itself. But, when the QR is scanned, the user will be redirected to the new URL. The change is instantaneous. To update the QR, make a HTTPS PUT to:
 [`PUT:/qr/v1/merchant-redirect/{id}`](https://vippsas.github.io/vipps-developer-docs/api/qr#operation/UpdateMerchantRedirectUrl)
 and put the new redirectUrl in the requestBody:
@@ -293,7 +293,7 @@ The
 [`DELETE:/qr/v1/merchant-redirect/{id}`](https://vippsas.github.io/vipps-developer-docs/api/qr#operation/DeleteMerchantRedirectQr)
 does what one might expect, it deletes the QR. Once deleted, merchants can generate a new QR with the same id but the already-printed-QR will never work again.
 
-In addition to the `DELETE`-endpoint, it is also possible to add a `ttl`-attribute in the original `POST`-request. This attribute sets how many seconds the QR will live, before it is deleted permanently. 
+In addition to the `DELETE`-endpoint, it is also possible to add a `ttl`-attribute in the original `POST`-request. This attribute sets how many seconds the QR will live, before it is deleted permanently.
 
 Tip: If you want the same QR in different formats, perform `GET` calls on the same `id` with different `accept` headers and test what works best.
 

--- a/vipps-qr-api.md
+++ b/vipps-qr-api.md
@@ -155,7 +155,7 @@ Before creating the QR code you must initiate a payment with the Vipps eCom API 
 [eCom API guide](https://github.com/vippsas/vipps-ecom-api/blob/master/vipps-ecom-api.md#initiate-payment-flow-phone-and-browser).
 
 The request to the ecom initiate endpoint
-[`POST:/ecomm/v2/payments`](https://vippsas.github.io/vipps-ecom-api/#/Vipps%20eCom%20API/initiatePaymentV3UsingPOST)
+[`POST:/ecomm/v2/payments`](https://vippsas.github.io/vipps-developer-docs/api/ecom#tag/Vipps-eCom-API/operation/initiatePaymentV3UsingPOST)
  will return a response like this (the `url` is truncated, but the format is correct):
 
 ```json
@@ -176,7 +176,7 @@ See the [step-by-step postman guide](vipps-qr-api-postman.md) for an example.
 Now that you have the `url` from the Vipps eCom API you can create a QR code
 using the following endpoint:
 
-[`POST:qr​/v1/`](https://vippsas.github.io/vipps-qr-api/redoc.html#operation/generateOtpQr)
+[`POST:qr​/v1/`](https://vippsas.github.io/vipps-developer-docs/api/qr#operation/generateOtpQr)
 
 Example of a request for a QR code image using `Accept: image/png`:
 
@@ -244,7 +244,7 @@ See the [step-by-step postman guide](vipps-qr-api-postman.md) for examples of ge
 #### Creation of Merchant Redirect QR
 
 To create a merchant redirect QR, make a HTTPS POST to:
-[`POST:/qr/v1/merchant-redirect`](https://vippsas.github.io/vipps-qr-api/redoc.html#operation/CreateMerchantRedirectQr)
+[`POST:/qr/v1/merchant-redirect`](https://vippsas.github.io/vipps-developer-docs/api/qr#operation/CreateMerchantRedirectQr)
 
 An example body like this:
 
@@ -270,7 +270,7 @@ See the [step-by-step postman guide](vipps-qr-api-postman.md) for an example.
 
 #### Updating and Deletion of QRs
 Updating QRs is a very similar procedure to creating them. When a QR is updated, nothing happens to the QR itself. But, when the QR is scanned, the user will be redirected to the new URL. The change is instantaneous. To update the QR, make a HTTPS PUT to:
-[`PUT:/qr/v1/merchant-redirect/{id}`](https://vippsas.github.io/vipps-qr-api/redoc.html#operation/UpdateMerchantRedirectUrl)
+[`PUT:/qr/v1/merchant-redirect/{id}`](https://vippsas.github.io/vipps-developer-docs/api/qr#operation/UpdateMerchantRedirectUrl)
 and put the new redirectUrl in the requestBody:
 
 ```json
@@ -290,7 +290,7 @@ And the response will be exactly the same as for generating the QR the first tim
 ```
 
 The
-[`DELETE:/qr/v1/merchant-redirect/{id}`](https://vippsas.github.io/vipps-qr-api/redoc.html#operation/DeleteMerchantRedirectQr)
+[`DELETE:/qr/v1/merchant-redirect/{id}`](https://vippsas.github.io/vipps-developer-docs/api/qr#operation/DeleteMerchantRedirectQr)
 does what one might expect, it deletes the QR. Once deleted, merchants can generate a new QR with the same id but the already-printed-QR will never work again.
 
 In addition to the `DELETE`-endpoint, it is also possible to add a `ttl`-attribute in the original `POST`-request. This attribute sets how many seconds the QR will live, before it is deleted permanently. 


### PR DESCRIPTION
Minor tweaks to readme. 
Set all the endpoint links to point to new website.  These were formerly pointing to redoc.html in the repo, so it was easy to change them to the new website, since it was just the prefix that changed.
Fixed markdown violations,